### PR TITLE
Remove Data[], message to state, modified test

### DIFF
--- a/src/subscribe.js
+++ b/src/subscribe.js
@@ -15,11 +15,10 @@ function parse(message) {
 function defaultDispatch(topic, message, packet) {
     const { state } = this;
     const m = parse(message);
-    const newData = [
-        m,
-        ...state.data
-    ];
-    this.setState({ data: newData });
+    
+    this.setState({
+      message: m
+    });
 };
 
 
@@ -42,7 +41,7 @@ export default function subscribe(opts = { dispatch: defaultDispatch }) {
                 this.client = props.client || context.mqtt;
                 this.state = {
                     subscribed: false,
-                    data: [],
+                    message: ''
                 };
             }
 
@@ -59,7 +58,7 @@ export default function subscribe(opts = { dispatch: defaultDispatch }) {
             render() {
                 return createElement(TargetComponent, {
                     ...omit(this.props, 'client'),
-                    data: this.state.data,
+                    message: this.state.message,
                     mqtt: this.client
                 });
             }

--- a/test/subscribe.spec.js
+++ b/test/subscribe.spec.js
@@ -45,8 +45,8 @@ describe('Subscribe', (test) => {
             <SubscribedComponent client={stub} />
         );
         stub.publish(demoTopic, demoMessage);
-        const data = mounted.first().prop('data');
-        t.true(data[0] === demoMessage);
+        const m = mounted.first().prop('message');
+        t.true(m === demoMessage);
     });
 
     test('receives JSON data and parses it', (t) => {
@@ -57,9 +57,9 @@ describe('Subscribe', (test) => {
             <SubscribedComponent client={stub} />
         );
         stub.publish(demoTopic, JSON.stringify(demoMessage));
-        const data = mounted.first().prop('data');
-        t.truthy(data[0]);
-        t.true(data[0].value === demoMessage.value);
+        const m = mounted.first().prop('message');
+        t.truthy(m);
+        t.true(m.value === demoMessage.value);
     })
 
 


### PR DESCRIPTION
- **Remove Data[]**: Because when the array is very large blocks browser. I think it is more useful for each app to manage the received data.
- Add **message** as a **state**. 
- Modified the tests